### PR TITLE
Add quarteira on peak description

### DIFF
--- a/MAnorm/classfy_by_M_value.sh
+++ b/MAnorm/classfy_by_M_value.sh
@@ -6,9 +6,9 @@ then
   echo "Usage: `basename $0` fold-change_cutoff_unbiased fold-change_cutoff_biased -log10p_cutoff_biased"
   exit
 fi
-sed '1d' MAnorm_result.xls | awk 'BEGIN {OFS="\t"}{print $1,$2,$3>"MAnorm_result.tmp"}'
-awk -v var1=$2 -v var2=$3 'BEGIN {OFS="\t"} {if($7 >= var1 && $9 > var2)print $1,$2,$3>"sample1_uniq_peaks.bed"}'  MAnorm_result.xls
-awk -v var1=$2 -v var2=$3 'BEGIN {OFS="\t"} {if($7 <= -var1 && $9 > var2)print $1,$2,$3>"sample2_uniq_peaks.bed"}'  MAnorm_result.xls
-awk -v var=$1 'BEGIN {OFS="\t"} {if($7<var && $7>-var)print $1,$2,$3>"unbiased_peaks.tmp"}'  MAnorm_result.xls
+# sed '1d' MAnorm_result.xls | awk 'BEGIN {OFS="\t"}{print $1,$2,$3>"MAnorm_result.tmp"}'
+awk -v var1=$2 -v var2=$3 'BEGIN {OFS="\t"} {if($4 == "unique_peak1" && $7 >= var1 && $9 > var2)print $1,$2,$3>"sample1_uniq_peaks.bed"}'  MAnorm_result.xls
+awk -v var1=$2 -v var2=$3 'BEGIN {OFS="\t"} {if($4 == "unique_peak2" && $7 <= -var1 && $9 > var2)print $1,$2,$3>"sample2_uniq_peaks.bed"}'  MAnorm_result.xls
+awk -v var=$1 'BEGIN {OFS="\t"} {if($4 ~ /common_peak*/ && $7<var && $7>-var)print $1,$2,$3>"unbiased_peaks.tmp"}'  MAnorm_result.xls
 mergeBed -i unbiased_peaks.tmp > unbiased_peaks.bed
 rm unbiased_peaks.tmp


### PR DESCRIPTION
1. "MAnorm_result.tmp" is not used later on.
2. If don't require on the "description" of a peak to be a "unique peak" or "common peak", it will output all types of peaks satisfy the M-value quarteira.